### PR TITLE
Grep failure was causing nodes to be terminated immediately every time.

### DIFF
--- a/replace.sh
+++ b/replace.sh
@@ -32,6 +32,11 @@ if ! $SCRIPT_DIR/cordon.sh $INSTANCE_ID; then
 	exit 1
 fi
 
+NODE_NAME=$(echo "INSTANCE_DETAIL" | jq ".Reservations[].Instances[].PrivateDnsName" | cut -d'"' -f 2)
+if [ -z "$NODE_NAME" ]; then
+        echo "replace ($INSTANCE_ID): warning: couldn't get node name, node will be terminated immediately."
+fi
+
 # check for pods to complete and then we can terminate.
 START_TIME=$(date +%s)
 while true; do


### PR DESCRIPTION
Since NODE_NAME was not set, this caused grep to fail and the script to evaluate that there were zero "waitable" pods on the node. This meant that in-progress builds were always cancelled on terminating nodes.